### PR TITLE
Support for larger files: save blobs in chunks

### DIFF
--- a/src/android/SaveDialog.java
+++ b/src/android/SaveDialog.java
@@ -15,6 +15,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 
 import java.io.FileOutputStream;
+import java.nio.channels.FileChannel;
 
 public class SaveDialog extends CordovaPlugin {
     private static final int LOCATE_FILE = 1;
@@ -27,7 +28,7 @@ public class SaveDialog extends CordovaPlugin {
         if (action.equals("locateFile")) {
             this.locateFile(args.getString(0), args.getString(1));
         } else if (action.equals("saveFile")) {
-            this.saveFile(Uri.parse(args.getString(0)), args.getString(1));
+            this.saveFile(Uri.parse(args.getString(0)), args.getString(1), args.getBoolean(2));
         } else {
             return false;
         }
@@ -63,12 +64,18 @@ public class SaveDialog extends CordovaPlugin {
         this.callbackContext = callbackContext;
     }
 
-    private void saveFile(Uri uri, String data) {
+    private void saveFile(Uri uri, String data, boolean clearFile) {
         try {
             byte[] rawData = Base64.decode(data, Base64.DEFAULT);
-            ParcelFileDescriptor pfd = cordova.getActivity().getContentResolver().openFileDescriptor(uri, "w");
+            ParcelFileDescriptor pfd = cordova.getActivity().getContentResolver().openFileDescriptor(uri, "wa");
             FileOutputStream fileOutputStream = new FileOutputStream(pfd.getFileDescriptor());
+
             try {
+                if (clearFile) {
+                    FileChannel fChan = fileOutputStream.getChannel();
+                    fChan.truncate(0);
+                }
+
                 fileOutputStream.write(rawData);
                 this.callbackContext.success(uri.toString());
             } catch (Exception e) {

--- a/www/android/SaveDialog.js
+++ b/www/android/SaveDialog.js
@@ -36,13 +36,21 @@ let saveFileInChunks = (uri, blob) => {
 
     return new Promise(async (resolve, reject) => {
         let i = 0;
+        let uri = '';
+        let error = null;
 
         while(writtenSize < blob.size) {
-            await saveNextChunk(i === 0).catch((err) => reject(err));
+            [uri, error] = await saveNextChunk(i === 0).then((result) => [result, null]).catch((err) => [null, err]);
+
+            if (error !== null) {
+                reject(error);
+                return;
+            }
+
             i++;
         }
 
-        resolve();
+        resolve(uri);
     });
 }
 

--- a/www/android/SaveDialog.js
+++ b/www/android/SaveDialog.js
@@ -7,10 +7,10 @@ let locateFile = (type, name) => new Promise((resolve, reject) => {
     exec(resolve, reject, "SaveDialog", "locateFile", [type || "application/octet-stream", name]);
 });
 
-let saveFile = (uri, blob) => new Promise((resolve, reject) => {
+let saveFile = (uri, blob, clearFile) => new Promise((resolve, reject) => {
     let reader = new FileReader();
     reader.onload = () => {
-        exec(resolve, reject, "SaveDialog", "saveFile", [uri, reader.result]);
+        exec(resolve, reject, "SaveDialog", "saveFile", [uri, reader.result, clearFile]);
     };
     reader.onerror = () => {
         reject(reader.error);
@@ -21,11 +21,36 @@ let saveFile = (uri, blob) => new Promise((resolve, reject) => {
     reader.readAsArrayBuffer(blob);
 });
 
+let saveFileInChunks = (uri, blob) => {
+    const BLOCK_SIZE = 1024 * 1024;
+    let writtenSize = 0;
+
+    function saveNextChunk(clearFile) {
+        const size = Math.min(BLOCK_SIZE, blob.size - writtenSize);
+        const chunk = blob.slice(writtenSize, writtenSize + size);
+
+        writtenSize += size;
+
+        return saveFile(uri, chunk, clearFile);
+    }
+
+    return new Promise(async (resolve, reject) => {
+        let i = 0;
+
+        while(writtenSize < blob.size) {
+            await saveNextChunk(i === 0).catch((err) => reject(err));
+            i++;
+        }
+
+        resolve();
+    });
+}
+
 module.exports = {
     saveFile(blob, name = "") {
         return keepBlob(blob) // see the “resume” event handler below
             .then(() => locateFile(blob.type, name))
-            .then(uri => saveFile(uri, blob))
+            .then(uri => saveFileInChunks(uri, blob))
             .then(uri => {
                 clearBlob();
                 return uri;


### PR DESCRIPTION
We detected issues when trying to save larger files (e.g. 50MB) with the SaveDialog plugin.

We resolved this issue by saving the file in 1MB chunks instead of a single save operation.

I thought that maybe others would benefit from this change as well.